### PR TITLE
Subsample tiles

### DIFF
--- a/vsm/include/raster/esa_s2.hpp
+++ b/vsm/include/raster/esa_s2.hpp
@@ -69,6 +69,8 @@ class ESA_S2_Image {
 
 		void set_tile_size(int tile_size);
 
+		void set_downscale_factor(int f);
+
 		void set_scl_class_map(unsigned char *class_map);
 
 		bool process(const std::filesystem::path &path_dir_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op);
@@ -77,5 +79,7 @@ class ESA_S2_Image {
 
 	protected:
 		unsigned char *scl_value_map;
+
+		int f_downscale;
 };
 

--- a/vsm/include/raster/raster_image.hpp
+++ b/vsm/include/raster/raster_image.hpp
@@ -85,7 +85,8 @@ class RasterImage {
 		unsigned char main_depth;
 		unsigned char main_num_components;
 
-		bool scale(float f, bool point_filter);
+		bool scale_f(float f, bool point_filter);
+		bool scale_to(unsigned int size, bool point_filter);
 		void remap_values(const unsigned char *values);
 
 	private:

--- a/vsm/include/raster/raster_image.hpp
+++ b/vsm/include/raster/raster_image.hpp
@@ -46,6 +46,26 @@ class NCException: public std::exception {
 		std::string full_message;
 };
 
+template <typename T>
+class RasterBufferPan {
+	public:
+		RasterBufferPan(unsigned long int size);
+		~RasterBufferPan();
+
+		T *v;
+};
+
+template <typename T>
+class RasterBufferRGB {
+	public:
+		RasterBufferRGB(unsigned long int size);
+		~RasterBufferRGB();
+
+		T *r;
+		T *g;
+		T *b;
+};
+
 class RasterImage {
 	public:
 		RasterImage();

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -25,7 +25,7 @@ const std::string ESA_S2_Image_Operator::data_type_name[ESA_S2_Image_Operator::D
 	"TCI", "SCL", "AOT", "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B10", "B11", "B12", "WVP", "GML", "S2CC", "S2CS"
 };
 
-ESA_S2_Image::ESA_S2_Image(): tile_size(512), scl_value_map(nullptr), f_downscale(-1) {}
+ESA_S2_Image::ESA_S2_Image(): tile_size(512), scl_value_map(nullptr), f_downscale(1) {}
 ESA_S2_Image::~ESA_S2_Image() {}
 
 void ESA_S2_Image::set_tile_size(int tile_size) {
@@ -37,7 +37,10 @@ void ESA_S2_Image::set_scl_class_map(unsigned char *class_map) {
 }
 
 void ESA_S2_Image::set_downscale_factor(int f) {
-	f_downscale = f;
+	if (f <= 0)
+		f_downscale = 1;
+	else
+		f_downscale = f;
 }
 
 bool ESA_S2_Image::process(const std::filesystem::path &path_dir_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op) {
@@ -133,10 +136,10 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 				if (scl_value_map != nullptr)
 					img_src.remap_values(scl_value_map);
 				// Scale SCL with point filter.
-				img_src.scale_to(tile_size * f_downscale, true);
+				img_src.scale_to((unsigned int) (tile_size / f_downscale), true);
 			} else {
 				// Scale other images with sinc filter.
-				img_src.scale_to(tile_size * f_downscale, false);
+				img_src.scale_to((unsigned int) (tile_size / f_downscale), false);
 			}
 
 			std::ostringstream ss_path_out, ss_path_out_png, ss_path_out_nc;

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -120,10 +120,6 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 	int w = img_src.main_geometry.width();
 	int h = img_src.main_geometry.height();
 
-	float div_f_downscaled = (float) div_f;
-	if (f_downscale > 0.0f)
-		div_f_downscaled /= f_downscale;
-
 	std::cout << "Processing " << path_in << std::endl;
 
 	// Subset the image, and store the subsets in a dedicated directory.
@@ -137,10 +133,10 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 				if (scl_value_map != nullptr)
 					img_src.remap_values(scl_value_map);
 				// Scale SCL with point filter.
-				img_src.scale(div_f_downscaled, true);
+				img_src.scale_to(tile_size * f_downscale, true);
 			} else {
 				// Scale other images with sinc filter.
-				img_src.scale(div_f_downscaled, false);
+				img_src.scale_to(tile_size * f_downscale, false);
 			}
 
 			std::ostringstream ss_path_out, ss_path_out_png, ss_path_out_nc;

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -127,9 +127,9 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 	std::cout << "Processing " << path_in << std::endl;
 
 	// Subset the image, and store the subsets in a dedicated directory.
-	for (int y=0; y<h; y+=tile_size_div) {
+	for (int y=0,yi=0; y<h; y+=tile_size_div,yi++) {
 		std::cout << " " << y << std::endl;
-		for (int x=0; x<w; x+=tile_size_div) {
+		for (int x=0,xi=0; x<w; x+=tile_size_div,xi++) {
 			img_src.load_subset(path_in, x, y, x + tile_size_div, y + tile_size_div);
 
 			// Remap pixel values for SCL.
@@ -145,7 +145,7 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 
 			std::ostringstream ss_path_out, ss_path_out_png, ss_path_out_nc;
 
-			ss_path_out << path_dir_out.string() << "/tile_" << x * div_f << "_" << y * div_f << "/";
+			ss_path_out << path_dir_out.string() << "/tile_" << xi << "_" << yi << "/";
 
 			std::filesystem::create_directories(ss_path_out.str());
 

--- a/vsm/lib/raster/jp2_image.cpp
+++ b/vsm/lib/raster/jp2_image.cpp
@@ -71,6 +71,9 @@ bool JP2_Image::load_header(const std::filesystem::path &path) {
 			throw std::exception();
 		}
 
+		// Limit to a single thread (allows to parallelize over multiple JP2 files).
+		opj_codec_set_threads(l_codec, 1);
+
 		// Read file header with image size, number of components, etc.
 		if (!opj_read_header(l_stream, l_codec, &l_image)) {
 			std::cerr << "ERROR: OpenJPEG: Failed to read header from " << path << std::endl;

--- a/vsm/lib/raster/raster_image.cpp
+++ b/vsm/lib/raster/raster_image.cpp
@@ -90,7 +90,7 @@ bool RasterImage::save(const std::filesystem::path &path) {
 	return false;
 }
 
-bool RasterImage::scale(float f, bool point_filter) {
+bool RasterImage::scale_f(float f, bool point_filter) {
 	if (subset != nullptr) {
 		// No scaling needed?
 		if (f >= 0.999f && f <= 1.001f)
@@ -98,6 +98,24 @@ bool RasterImage::scale(float f, bool point_filter) {
 
 		Magick::Geometry geom_orig = subset->size();
 		Magick::Geometry geom_new(geom_orig.width() * f, geom_orig.height() * f);
+		if (point_filter)
+			subset->filterType(Magick::PointFilter);
+		else
+			subset->filterType(Magick::SincFilter);
+		subset->resize(geom_new);
+		return true;
+	}
+	return false;
+}
+
+bool RasterImage::scale_to(unsigned int size, bool point_filter) {
+	if (subset != nullptr) {
+		Magick::Geometry geom_orig = subset->size();
+
+		if (geom_orig.width() == size && geom_orig.height() == size)
+			return true;
+
+		Magick::Geometry geom_new(size, size);
 		if (point_filter)
 			subset->filterType(Magick::PointFilter);
 		else

--- a/vsm/lib/raster/raster_image.cpp
+++ b/vsm/lib/raster/raster_image.cpp
@@ -18,6 +18,28 @@
 #include <climits>
 
 
+template<typename T>
+RasterBufferPan<T>::RasterBufferPan(unsigned long int size) {
+	v = new T[size];
+}
+template<typename T>
+RasterBufferPan<T>::~RasterBufferPan() {
+	delete [] v;
+}
+
+template<typename T>
+RasterBufferRGB<T>::RasterBufferRGB(unsigned long int size) {
+	r = new T[size];
+	g = new T[size];
+	b = new T[size];
+}
+template<typename T>
+RasterBufferRGB<T>::~RasterBufferRGB() {
+	delete [] r;
+	delete [] g;
+	delete [] b;
+}
+
 RasterImage::RasterImage(): main_depth(0), main_num_components(0), subset(nullptr) {}
 RasterImage::~RasterImage() {
 	clear();
@@ -95,11 +117,11 @@ void RasterImage::remap_values(const unsigned char *values) {
 
 		Magick::PixelPacket *px = subset->getPixels(0, 0, w, h);
 
-		register double src_val, dst_val;
+		float src_val, dst_val;
 
 		for (unsigned int i=0; i<size; i++) {
 			src_val = Magick::ColorGray(px[i]).shade();
-			dst_val = values[(unsigned char) (255 * src_val)] / 255.0;
+			dst_val = values[(unsigned char) (255 * src_val)] / 255.0f;
 			px[i] = Magick::ColorGray(dst_val);
 		}
 
@@ -169,7 +191,7 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 
 	try {
 		Magick::ImageType imgtype = subset->type();
-		
+
 		if (imgtype == Magick::GrayscaleType)
 			c = 1;
 		else if (imgtype == Magick::TrueColorType)
@@ -208,42 +230,45 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 		int nd = sizeof(dimids) / sizeof(dimids[0]);
 
 		Magick::PixelPacket *src_px = subset->getPixels(0, 0, w, h);
-		double src_val;
+		float src_val;
 
 		// Store content.
 		if (c == 1) {
 			if (main_depth > 8) {
-				float dst_px[size];
 				unsigned int yw, fyw;
+
+				RasterBufferPan<float> dst_px(size);
 
 				for (unsigned int y=0; y<h; y++) {
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
 						src_val = Magick::ColorGray(src_px[yw + x]).shade();
-						dst_px[fyw + x] = (float) src_val;
+						dst_px.v[fyw + x] = src_val;
 					}
 				}
 
-				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px, deflate_level);
+				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v, deflate_level);
 			} else {
-				unsigned char dst_px[size];
 				unsigned int yw, fyw;
+
+				RasterBufferPan<unsigned char> dst_px(size);
 
 				for (unsigned int y=0; y<h; y++) {
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
 						src_val = Magick::ColorGray(src_px[yw + x]).shade();
-						dst_px[fyw + x] = (int) (src_val * 255);
+						dst_px.v[fyw + x] = (int) (src_val * 255);
 					}
 				}
 
-				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px, deflate_level);
+				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v, deflate_level);
 			}
 		} else if (c == 3) {
-			unsigned char dst_px_r[size], dst_px_g[size], dst_px_b[size];
 			unsigned int yw, fyw;
+
+			RasterBufferRGB<unsigned char> dst_px(size);
 
 			for (unsigned int y=0; y<h; y++) {
 				yw = y * w;
@@ -251,15 +276,15 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 				for (unsigned int x=0; x<w; x++) {
 					//! \todo TODO:: Figure out why pixels of an 8-bit image are stored as 16-bit values.
 					// Is it due to the TrueColorType?
-					dst_px_r[fyw + x] = (int) (src_px[yw + x].red * 255 / 65535.0f);
-					dst_px_g[fyw + x] = (int) (src_px[yw + x].green * 255 / 65535.0f);
-					dst_px_b[fyw + x] = (int) (src_px[yw + x].blue * 255 / 65535.0f);
+					dst_px.r[fyw + x] = (int) (src_px[yw + x].red * 255 / 65535.0f);
+					dst_px.g[fyw + x] = (int) (src_px[yw + x].green * 255 / 65535.0f);
+					dst_px.b[fyw + x] = (int) (src_px[yw + x].blue * 255 / 65535.0f);
 				}
 			}
 
-			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_R", w, h, dimids, nd, (const void *) dst_px_r, deflate_level);
-			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_G", w, h, dimids, nd, (const void *) dst_px_g, deflate_level);
-			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_B", w, h, dimids, nd, (const void *) dst_px_b, deflate_level);
+			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_R", w, h, dimids, nd, (const void *) dst_px.r, deflate_level);
+			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_G", w, h, dimids, nd, (const void *) dst_px.g, deflate_level);
+			add_layer_to_netcdf(ncid, path, name_in_netcdf + "_B", w, h, dimids, nd, (const void *) dst_px.b, deflate_level);
 		}
 
 	} catch (NCException &e) {
@@ -269,6 +294,7 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 		// Close the file.
 		if ((retval = nc_close(ncid)))
 			std::cerr << "Failed to close NetCDF file \"" << path << "\", error " << retval << std::endl;
+
 		return false;
 	}
 
@@ -277,6 +303,7 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 		std::cerr << "Failed to close NetCDF file \"" << path << "\", error " << retval << std::endl;
 		return false;
 	}
+
 	return true;
 }
 

--- a/vsm/vsm/main.cpp
+++ b/vsm/vsm/main.cpp
@@ -91,10 +91,12 @@ int main(int argc, char* argv[]) {
 		<< std::endl;
 
 	if (argc < 2) {
-		std::cerr << "Usage: cvat-vsm [-d PATH][-r CVAT_XML [-n NETCDF]]" << std::endl
+		std::cerr << "Usage: cvat-vsm [-d PATH] [-r CVAT_XML [-n NETCDF]] [-S TILESIZE [-s SHRINK]]" << std::endl
 			<< "\twhere PATH points to the .SAFE directory of an ESA S2 L2A product." << std::endl
-			<< "\tCVAT_XML to an annotations vector layer which is to be rasterized." << std::endl
-			<< "\tNETCDF to a NetCDF file to be updated with the rasterized annotations." << std::endl;
+			<< "\tCVAT_XML points to an annotations vector layer which is to be rasterized." << std::endl
+			<< "\tNETCDF points to a NetCDF file to be updated with the rasterized annotations." << std::endl
+			<< "\tTILESIZE is the number of pixels per the edge of a square subtile (default: 512)." << std::endl
+			<< "\tSHRINK is the factor by which to downscale from the 10 x 10 m^2 S2 bands (default: -1 (original size))." << std::endl;
 		return 1;
 	}
 
@@ -102,6 +104,8 @@ int main(int argc, char* argv[]) {
 	Magick::InitializeMagick(*argv);
 
 	std::string arg_path_dir, arg_path_rasterize, arg_path_nc;
+	unsigned int tilesize = 512;
+	int downscale = -1;
 	for (int i=0; i<argc; i++) {
 		if (!strncmp(argv[i], "-d", 2))
 			arg_path_dir.assign(argv[i + 1]);
@@ -109,6 +113,10 @@ int main(int argc, char* argv[]) {
 			arg_path_rasterize.assign(argv[i + 1]);
 		else if (!strncmp(argv[i], "-n", 2))
 			arg_path_nc.assign(argv[i + 1]);
+		else if (!strncmp(argv[i], "-S", 2))
+			tilesize = atoi(argv[i + 1]);
+		else if (!strncmp(argv[i], "-s", 2))
+			downscale = atoi(argv[i + 1]);
 	}
 
 	if (arg_path_dir.length() > 0) {
@@ -117,7 +125,9 @@ int main(int argc, char* argv[]) {
 		std::filesystem::path path_dir_in(arg_path_dir);
 		std::filesystem::path path_dir_out(path_dir_in.parent_path().string() + "/" + path_dir_in.stem().string() + ".CVAT");
 
+		img.set_tile_size(tilesize);
 		img.set_scl_class_map(new_class_map);
+		img.set_downscale_factor(downscale);
 		img.process(path_dir_in, path_dir_out, img_op);
 	}
 


### PR DESCRIPTION
Support for:

1. tiles of arbitrary size,
2. subsampling the original image, in order to support labels from the open-source dataset.

Side-effects:

1. Tile indices used instead of pixel coordinates in directory names.
2. Directory structure (and CVAT task names) incompatible with previous versions of CVAT-VSM.