### PR TITLE
Support for L1C and Baetens & Hagolle classification maps

### DIFF
--- a/vsm/include/raster/bhc_tif.hpp
+++ b/vsm/include/raster/bhc_tif.hpp
@@ -1,0 +1,28 @@
+// Baetens & Hagolle classification map, in TIF format
+//
+// Copyright 2020 KappaZeta Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "raster/tif_image.hpp"
+#include <filesystem>
+
+
+class BHC_TIF_Image: public TIF_Image {
+	public:
+		BHC_TIF_Image();
+		~BHC_TIF_Image();
+};
+

--- a/vsm/include/raster/esa_s2.hpp
+++ b/vsm/include/raster/esa_s2.hpp
@@ -42,6 +42,7 @@ public:
 		DT_GML,	///< Vector mask layer
 		DT_S2CC,	///< Sen2cor cloud probabilities (8 bit), 20 m
 		DT_S2CS,	///< Sen2cor snow probabilities (8 bit), 20 m
+		DT_BHC,	///< Baetens & Hagolle classification map, 60 m
 		DT_COUNT
 	};
 
@@ -55,6 +56,7 @@ public:
 	};
 
 	static const std::string data_type_name[DT_COUNT];
+	static const unsigned char bhc_scl_value_map[8];
 
 	virtual bool operator()(const std::filesystem::path &path, data_type_t type) { return false; }
 };
@@ -75,7 +77,8 @@ class ESA_S2_Image {
 
 		bool process(const std::filesystem::path &path_dir_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op);
 
-		bool split(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution);
+		bool splitJP2(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution);
+		bool splitTIF(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution);
 
 	protected:
 		unsigned char *scl_value_map;

--- a/vsm/include/raster/tif_image.hpp
+++ b/vsm/include/raster/tif_image.hpp
@@ -1,0 +1,34 @@
+// Tiled loading of a TIF image
+//
+// Copyright 2020 KappaZeta Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "raster/raster_image.hpp"
+
+#include <filesystem>
+
+
+class TIF_Image: public RasterImage {
+	public:
+		TIF_Image();
+		~TIF_Image();
+
+		bool load_header(const std::filesystem::path &path);
+
+		bool load_subset(const std::filesystem::path &path, int da_x0, int da_y0, int da_x1, int da_y1);
+};
+
+

--- a/vsm/lib/raster/bhc_tif.cpp
+++ b/vsm/lib/raster/bhc_tif.cpp
@@ -1,0 +1,22 @@
+// Baetens & Hagolle classification map, in TIF format
+//
+// Copyright 2020 KappaZeta Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "raster/bhc_tif.hpp"
+
+
+BHC_TIF_Image::BHC_TIF_Image() {}
+BHC_TIF_Image::~BHC_TIF_Image() {}
+

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -17,12 +17,25 @@
 #include "raster/esa_s2.hpp"
 #include "raster/esa_s2_scl_jp2.hpp"
 #include "raster/esa_s2_band_jp2.hpp"
+#include "raster/bhc_tif.hpp"
 
 #include "util/text.hpp"
 
 
 const std::string ESA_S2_Image_Operator::data_type_name[ESA_S2_Image_Operator::DT_COUNT] = {
-	"TCI", "SCL", "AOT", "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B10", "B11", "B12", "WVP", "GML", "S2CC", "S2CS"
+	"TCI", "SCL", "AOT", "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B10", "B11", "B12", "WVP", "GML", "S2CC", "S2CS", "BHC"
+};
+
+//! Map BHC classes to SCL classes.
+const unsigned char ESA_S2_Image_Operator::bhc_scl_value_map[8] = {
+	0, // 0  NO_DATA                  -> NO_DATA
+	0, // 1  NOT_USED                 -> NO_DATA
+	8, // 2  LOW_CLOUDS               -> CLOUD_MEDIUM_PROBABILITY
+	9, // 3  HIGH_CLOUDS              -> CLOUD_HIGH_PROBABILITY
+	3, // 4  CLOUD_SHADOWS            -> CLOUD_SHADOWS
+	4, // 5  LAND                     -> VEGETATION
+	6, // 6  WATER                    -> WATER
+	11 // 7  SNOW                     -> SNOW
 };
 
 ESA_S2_Image::ESA_S2_Image(): tile_size(512), scl_value_map(nullptr), f_downscale(1) {}
@@ -48,62 +61,118 @@ bool ESA_S2_Image::process(const std::filesystem::path &path_dir_in, const std::
 
 	for (const auto &granule_entry: std::filesystem::directory_iterator(path_dir_in.string() + "/GRANULE/")) {
 		data_resolution = ESA_S2_Image_Operator::DR_10M;
-		for (const auto &r10m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R10m/")) {
+		// Files within an L2A product with a 10 m resolution.
+		if (std::filesystem::is_directory(granule_entry.path().string() + "/IMG_DATA/R10m/")) {
+			for (const auto &r10m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R10m/")) {
+				//! \todo Map these
+				if (endswith(r10m_entry.path().string(), "_TCI_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_TCI, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_AOT_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_AOT, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_WVP_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_WVP, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_B02_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B02, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_B03_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B03, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_B04_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B04, data_resolution);
+				} else if (endswith(r10m_entry.path().string(), "_B08_10m.jp2")) {
+					splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B08, data_resolution);
+				}
+			}
+		}
+		// Files within an L1C product with a 10 m resolution.
+		for (const auto &r10m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/")) {
 			//! \todo Map these
-			if (endswith(r10m_entry.path().string(), "_TCI_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_TCI, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_AOT_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_AOT, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_WVP_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_WVP, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_B02_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B02, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_B03_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B03, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_B04_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B04, data_resolution);
-			} else if (endswith(r10m_entry.path().string(), "_B08_10m.jp2")) {
-				split(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B08, data_resolution);
+			if (endswith(r10m_entry.path().string(), "_TCI.jp2")) {
+				splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_TCI, data_resolution);
+			} else if (endswith(r10m_entry.path().string(), "_B02.jp2")) {
+				splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B02, data_resolution);
+			} else if (endswith(r10m_entry.path().string(), "_B03.jp2")) {
+				splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B03, data_resolution);
+			} else if (endswith(r10m_entry.path().string(), "_B04.jp2")) {
+				splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B04, data_resolution);
+			} else if (endswith(r10m_entry.path().string(), "_B08.jp2")) {
+				splitJP2(r10m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B08, data_resolution);
 			}
 		}
 
 		data_resolution = ESA_S2_Image_Operator::DR_20M;
-		for (const auto &r20m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R20m/")) {
-			if (endswith(r20m_entry.path().string(), "_SCL_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_SCL, data_resolution);
-			} else if (endswith(r20m_entry.path().string(), "_B05_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B05, data_resolution);
-			} else if (endswith(r20m_entry.path().string(), "_B06_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B06, data_resolution);
-			} else if (endswith(r20m_entry.path().string(), "_B8A_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B8A, data_resolution);
-			} else if (endswith(r20m_entry.path().string(), "_B11_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B11, data_resolution);
-			} else if (endswith(r20m_entry.path().string(), "_B12_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B12, data_resolution);
+		// Files within an L2A product with a 20 m resolution.
+		if (std::filesystem::is_directory(granule_entry.path().string() + "/IMG_DATA/R20m/")) {
+			for (const auto &r20m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R20m/")) {
+				if (endswith(r20m_entry.path().string(), "_SCL_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_SCL, data_resolution);
+				} else if (endswith(r20m_entry.path().string(), "_B05_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B05, data_resolution);
+				} else if (endswith(r20m_entry.path().string(), "_B06_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B06, data_resolution);
+				} else if (endswith(r20m_entry.path().string(), "_B8A_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B8A, data_resolution);
+				} else if (endswith(r20m_entry.path().string(), "_B11_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B11, data_resolution);
+				} else if (endswith(r20m_entry.path().string(), "_B12_20m.jp2")) {
+					splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B12, data_resolution);
+				}
+			}
+		}
+		// Files within an L1C product with a 20 m resolution.
+		for (const auto &r20m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/")) {
+			if (endswith(r20m_entry.path().string(), "_B05.jp2")) {
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B05, data_resolution);
+			} else if (endswith(r20m_entry.path().string(), "_B06.jp2")) {
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B06, data_resolution);
+			} else if (endswith(r20m_entry.path().string(), "_B8A.jp2")) {
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B8A, data_resolution);
+			} else if (endswith(r20m_entry.path().string(), "_B11.jp2")) {
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B11, data_resolution);
+			} else if (endswith(r20m_entry.path().string(), "_B12.jp2")) {
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B12, data_resolution);
 			}
 		}
 		// Split Sen2cor cloudmask probabilities.
 		for (const auto &r20m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/QI_DATA")) {
 			if (endswith(r20m_entry.path().string(), "MSK_CLDPRB_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_S2CC, data_resolution);
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_S2CC, data_resolution);
 			} else if (endswith(r20m_entry.path().string(), "MSK_SNWPRB_20m.jp2")) {
-				split(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_S2CS, data_resolution);
+				splitJP2(r20m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_S2CS, data_resolution);
 			}
 		}
 
 		data_resolution = ESA_S2_Image_Operator::DR_60M;
-		for (const auto &r60m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R60m/")) {
-			if (endswith(r60m_entry.path().string(), "_B01_60m.jp2")) {
-				split(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B01, data_resolution);
-			} else if (endswith(r60m_entry.path().string(), "_B09_60m.jp2")) {
-				split(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B09, data_resolution);
+		// Files within an L2A product with a 60 m resolution.
+		if (std::filesystem::is_directory(granule_entry.path().string() + "/IMG_DATA/R60m/")) {
+			for (const auto &r60m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/R60m/")) {
+				if (endswith(r60m_entry.path().string(), "_B01_60m.jp2")) {
+					splitJP2(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B01, data_resolution);
+				} else if (endswith(r60m_entry.path().string(), "_B09_60m.jp2")) {
+					splitJP2(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B09, data_resolution);
+				}
+			}
+		}
+		// Files within an L1C product with a 60 m resolution.
+		for (const auto &r60m_entry: std::filesystem::directory_iterator(granule_entry.path().string() + "/IMG_DATA/")) {
+			if (endswith(r60m_entry.path().string(), "_B01.jp2")) {
+				splitJP2(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B01, data_resolution);
+			} else if (endswith(r60m_entry.path().string(), "_B09.jp2")) {
+				splitJP2(r60m_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_B09, data_resolution);
+			}
+		}
+	}
+
+	// Split Baetens & Hagolle classification maps with a 60 m resolution.
+	if (std::filesystem::is_directory(path_dir_in.string() + "/ref_dataset/Classification/")) {
+		for (const auto &classification_entry: std::filesystem::directory_iterator(path_dir_in.string() + "/ref_dataset/Classification/")) {
+			data_resolution = ESA_S2_Image_Operator::DR_60M;
+			if (endswith(classification_entry.path().string(), "classification_map.tif")) {
+				splitTIF(classification_entry.path(), path_dir_out, op, ESA_S2_Image_Operator::DT_BHC, data_resolution);
 			}
 		}
 	}
 }
 
-bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution) {
+bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution) {
 	ESA_S2_Band_JP2_Image img_src;
 	bool retval = true;
 
@@ -140,6 +209,68 @@ bool ESA_S2_Image::split(const std::filesystem::path &path_in, const std::filesy
 			} else {
 				// Scale other images with sinc filter.
 				img_src.scale_to((unsigned int) (tile_size / f_downscale), false);
+			}
+
+			std::ostringstream ss_path_out, ss_path_out_png, ss_path_out_nc;
+
+			ss_path_out << path_dir_out.string() << "/tile_" << xi << "_" << yi << "/";
+
+			std::filesystem::create_directories(ss_path_out.str());
+
+			ss_path_out_nc << ss_path_out.str() << "bands.nc";
+			ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << (int) xf << "_" << (int) yf << ".png";
+
+			// Save PNG.
+			img_src.save(ss_path_out_png.str());
+			// Add to NetCDF.
+			img_src.add_to_netcdf(ss_path_out_nc.str(), ESA_S2_Image_Operator::data_type_name[data_type], 9);
+
+			// Potential post-processing of the file.
+			if (!op(ss_path_out_png.str(), data_type))
+				return false;
+		}
+	}
+
+	std::cout << path_in << std::endl;
+
+	return true;
+}
+
+bool ESA_S2_Image::splitTIF(const std::filesystem::path &path_in, const std::filesystem::path &path_dir_out, ESA_S2_Image_Operator &op, ESA_S2_Image_Operator::data_type_t data_type, ESA_S2_Image_Operator::data_resolution_t data_resolution) {
+	BHC_TIF_Image img_src;
+	bool retval = true;
+
+	float div_f = 1.0f;
+	if (data_resolution == ESA_S2_Image_Operator::DR_20M)
+		div_f = 2.0f;
+	else if (data_resolution == ESA_S2_Image_Operator::DR_60M)
+		div_f = 6.0f;
+
+	float tile_size_div = tile_size / div_f;
+
+	// Get image dimensions.
+	retval &= img_src.load_header(path_in);
+
+	int w = img_src.main_geometry.width();
+	int h = img_src.main_geometry.height();
+
+	std::cout << "Processing " << path_in << std::endl;
+
+	// Subset the image, and store the subsets in a dedicated directory.
+	int xi, yi;
+	float xf, yf;
+	int xi0 = 0, yi0 = 0;
+	for (yi=yi0, yf=yi*tile_size_div; yf<(float)h; yf+=tile_size_div,yi++) {
+		for (xi=xi0, xf=xi*tile_size_div; xf<(float)w; xf+=tile_size_div,xi++) {
+			img_src.load_subset(path_in, (int) xf, (int) yf, (int) (xf + tile_size_div), (int) (yf + tile_size_div));
+
+			// Remap pixel values from BHC into SCL and then from SCL into the desired classes.
+			if (data_type == ESA_S2_Image_Operator::DT_BHC) {
+				img_src.remap_values(ESA_S2_Image_Operator::bhc_scl_value_map);
+				if (scl_value_map != nullptr)
+					img_src.remap_values(scl_value_map);
+				// Scale BHC with point filter.
+				img_src.scale_to((unsigned int) (tile_size / f_downscale), true);
 			}
 
 			std::ostringstream ss_path_out, ss_path_out_png, ss_path_out_nc;

--- a/vsm/lib/raster/tif_image.cpp
+++ b/vsm/lib/raster/tif_image.cpp
@@ -1,0 +1,79 @@
+// Tiled loading of a TIF image
+//
+// Copyright 2020 KappaZeta Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "raster/tif_image.hpp"
+#include <cstring>
+
+
+TIF_Image::TIF_Image() {}
+TIF_Image::~TIF_Image() {}
+
+bool TIF_Image::load_header(const std::filesystem::path &path) {
+	if (subset != nullptr)
+		clear();
+
+	subset = new Magick::Image();
+	subset->quiet(false);
+	subset->ping(path.string());
+
+	main_geometry = subset->size();
+	main_depth = subset->depth();
+
+	Magick::ImageType imgtype = subset->type();
+	if (imgtype == Magick::GrayscaleType || imgtype == Magick::BilevelType)
+		main_num_components = 1;
+	else if (imgtype == Magick::TrueColorType)
+		main_num_components = 3;
+
+	return true;
+}
+
+bool TIF_Image::load_subset(const std::filesystem::path &path, int da_x0, int da_y0, int da_x1, int da_y1) {
+	//! \todo Support tiled TIF.
+
+	if (subset != nullptr)
+		clear();
+
+	Magick::Image img(path);
+	img.quiet(false);
+
+	Magick::ImageType imgtype = img.type();
+	if (imgtype == Magick::BilevelType)
+		img.type(Magick::GrayscaleType);
+
+	main_geometry = img.size();
+	main_depth = img.depth();
+
+	if (imgtype == Magick::TrueColorType) {
+		main_num_components = 3;
+		subset = new Magick::Image(Magick::Geometry(da_x1 - da_x0, da_y1 - da_y0), Magick::ColorRGB(0, 0, 0));
+	} else {
+		main_num_components = 1;
+		subset = new Magick::Image(Magick::Geometry(da_x1 - da_x0, da_y1 - da_y0), Magick::ColorGray(0));
+	}
+
+	subset->quiet(false);
+	subset->type(img.type());
+	subset->depth(img.depth());
+
+	Magick::Geometry geom_new(da_x1 - da_x0, da_y1 - da_y0, da_x0, da_y0);
+	img.crop(geom_new);
+
+	subset->composite(img, Magick::NorthWestGravity, Magick::CopyCompositeOp);
+
+	return true;
+}
+


### PR DESCRIPTION
Support for splitting S2 L1C products.
Support for converting and splitting Baetens & Hagolle classification maps from https://zenodo.org/record/1460961#.X5qpT66xWAl.