### PR TITLE
-d relative path support

### DIFF
--- a/vsm/include/version.hpp
+++ b/vsm/include/version.hpp
@@ -17,9 +17,10 @@
 #pragma once
 
 #define CM_CONVERTER_NAME_STR		"cm-vsm"
-#define CM_CONVERTER_VERSION_STR	"0.1.15"
+#define CM_CONVERTER_VERSION_STR	"0.1.16"
 
 // Changelog
+//  0.1.16  Relative path support for command-line parameters.
 //  0.1.15  Bands.nc filename was fixed for -d argument and unnecessary functions have been removed.
 //  0.1.14  Fixed name for bands file from L2A rasters.
 //  0.1.13  Shortened product name and tile indexes in NetCDF files' names.

--- a/vsm/vsm/main.cpp
+++ b/vsm/vsm/main.cpp
@@ -157,6 +157,10 @@ int main(int argc, char* argv[]) {
 		ESA_S2_Image img;
 		ImageOperator img_op;
 		std::filesystem::path path_dir_in(arg_path_s2_dir);
+		if (!path_dir_in.is_absolute())
+		{
+			path_dir_in = std::filesystem::absolute(arg_path_s2_dir);
+		}
 		std::filesystem::path path_dir_out(path_dir_in.parent_path().string() + "/" + path_dir_in.stem().string() + ".CVAT");
 		std::vector<std::string> bands;
 

--- a/vsm/vsm/main.cpp
+++ b/vsm/vsm/main.cpp
@@ -157,8 +157,7 @@ int main(int argc, char* argv[]) {
 		ESA_S2_Image img;
 		ImageOperator img_op;
 		std::filesystem::path path_dir_in(arg_path_s2_dir);
-		if (!path_dir_in.is_absolute())
-		{
+		if (!path_dir_in.is_absolute()) {
 			path_dir_in = std::filesystem::absolute(arg_path_s2_dir);
 		}
 		std::filesystem::path path_dir_out(path_dir_in.parent_path().string() + "/" + path_dir_in.stem().string() + ".CVAT");
@@ -193,7 +192,13 @@ int main(int argc, char* argv[]) {
 		CVATRasterizer rasterizer;
 
 		std::filesystem::path path_in(arg_path_rasterize);
+		if (!path_in.is_absolute()) {
+			path_in = std::filesystem::absolute(arg_path_rasterize);
+		}
 		std::filesystem::path path_out_nc(arg_path_nc);
+		if (!path_out_nc.is_absolute()) {
+			path_out_nc = std::filesystem::absolute(arg_path_nc);
+		}
 
 		rasterizer.image.set_deflate_level(deflatelevel);
 
@@ -216,7 +221,13 @@ int main(int argc, char* argv[]) {
 		SuperviselyRasterizer r;
 
 		std::filesystem::path path_in(arg_path_supervisely);
+		if (!path_in.is_absolute()) {
+			path_in = std::filesystem::absolute(arg_path_supervisely);
+		}
 		std::filesystem::path path_out_nc(arg_path_nc);
+		if (!path_out_nc.is_absolute()) {
+			path_out_nc = std::filesystem::absolute(arg_path_nc);
+		}
 
 		r.image.set_deflate_level(deflatelevel);
 
@@ -232,6 +243,9 @@ int main(int argc, char* argv[]) {
 		SegmentsAIRaster r;
 
 		std::filesystem::path path_in(arg_path_cvat_sai_dir);
+		if (!path_in.is_absolute()) {
+			path_in = std::filesystem::absolute(arg_path_cvat_sai_dir);
+		}
 
 		r.set_deflate_level(deflatelevel);
 


### PR DESCRIPTION
Currently cm-vsm can be invoked only with full path to .SAFE folder, now it can be invoked in the .SAFE's parent folder with cm_vsm -d name_of_safe_folder.SAFE