### PR TITLE
Optimize01

### DIFF
--- a/vsm/include/raster/esa_s2.hpp
+++ b/vsm/include/raster/esa_s2.hpp
@@ -69,11 +69,20 @@ public:
 
 	/**
 	 * Callback for potential post-processing on the sub-tiles.
-	 * @param path Path to the sub-tile file.
+	 * @param path Path to the sub-tile subdirectory.
 	 * @param type File type.
 	 * @return True on success, false to abort sub-tile processing.
 	 */
 	virtual bool operator()(const std::filesystem::path &path, data_type_t type) { (void) path; (void) type; return false; }
+};
+
+
+class EmptyImageOperator: public ESA_S2_Image_Operator {
+public:
+	/**
+	 * Image operator which simply returns successfully without any actual processing.
+	 */
+	bool operator()(const std::filesystem::path &path, data_type_t type) { (void) path; (void) type; return true; }
 };
 
 
@@ -121,6 +130,12 @@ class ESA_S2_Image {
 		void set_png_output(bool enabled);
 
 		/**
+		 * Enable / disable tiled reading (reduced RAM footprint, at the cost of longer processing time).
+		 * @param enabled False to read the whole JP2 file into RAM, True to read the JP2 file in tiles.
+		 */
+		void set_tiled_input(bool enabled);
+
+		/**
 		 * Extract S2 product name from file path.
 		 * @return Product name as a string.
 		 */
@@ -150,6 +165,7 @@ class ESA_S2_Image {
 		std::string resampling_method_name;	///< Name of the resampling method used for all bands except classification masks.
 
 		bool store_png;	///< Whether to store intermediate output in PNG files or not.
+		bool read_tiled;	///< Whether to read JP2 files in tiles, or to read full images into RAM.
 
 		/**
 		 * Split a JP2 file into sub-tiles.

--- a/vsm/include/raster/esa_s2.hpp
+++ b/vsm/include/raster/esa_s2.hpp
@@ -136,6 +136,12 @@ class ESA_S2_Image {
 		void set_tiled_input(bool enabled);
 
 		/**
+		 * Set the number of threads to parallelize to.
+		 * @param num_threads Number of threads (0 for default, negative to use all available threads).
+		 */
+		void set_num_threads(int num_threads);
+
+		/**
 		 * Extract S2 product name from file path.
 		 * @return Product name as a string.
 		 */
@@ -166,6 +172,7 @@ class ESA_S2_Image {
 
 		bool store_png;	///< Whether to store intermediate output in PNG files or not.
 		bool read_tiled;	///< Whether to read JP2 files in tiles, or to read full images into RAM.
+		int num_threads;	///< Number of threads to parallelize to.
 
 		/**
 		 * Split a JP2 file into sub-tiles.

--- a/vsm/include/raster/jp2_image.hpp
+++ b/vsm/include/raster/jp2_image.hpp
@@ -25,15 +25,50 @@ class JP2_Image: public RasterImage {
 	public:
 		JP2_Image();
 		~JP2_Image();
-		
+
+		/**
+		 * Load the header of a JP2 file.
+		 * @param[in] path Path to the JP2 file.
+		 * @return True on success, False otherwise.
+		 */
 		bool load_header(const std::filesystem::path &path);
-		
+
+		/**
+		 * Load a subset of a JP2 file.
+		 * @param[in] path Path to the JP2 file.
+		 * @param[in] da_x0 Left side of the decode area, in pixels.
+		 * @param[in] da_y0 Top side of the decode area, in pixels.
+		 * @param[in] da_x1 Right side of the decode area, in pixels.
+		 * @param[in] da_y1 Bottom side of the decode area, in pixels.
+		 * @return True on success, False otherwise.
+		 */
 		bool load_subset(const std::filesystem::path &path, int da_x0, int da_y0, int da_x1, int da_y1);
+
+		/**
+		 * Load the whole JP2 file in RAM.
+		 * @param[in] path Path to the JP2 file.
+		 * @return True on success, False otherwise.
+		 */
+		bool load_whole(const std::filesystem::path &path);
+
+		/**
+		 * Subset the whole JP2 file.
+		 * @param[in] da_x0 Left side of the decode area, in pixels.
+		 * @param[in] da_y0 Top side of the decode area, in pixels.
+		 * @param[in] da_x1 Right side of the decode area, in pixels.
+		 * @param[in] da_y1 Bottom side of the decode area, in pixels.
+		 * @return True on success, False otherwise.
+		 */
+		bool subset_whole(int da_x0, int da_y0, int da_x1, int da_y1);
 
 		static void error_callback(const char *msg, void *client_data);
 
 		static void warning_callback(const char *msg, void *client_data);
 
 		static void info_callback(const char *msg, void *client_data);
+
+	private:
+		//! The whole decoded image.
+		Magick::Image *whole_image;
 };
 

--- a/vsm/include/raster/raster_image.hpp
+++ b/vsm/include/raster/raster_image.hpp
@@ -152,6 +152,12 @@ class RasterImage {
 		Magick::FilterTypes set_resampling_filter(const std::string &filter_name);
 
 		/**
+		 * Set the number of threads to parallelize to.
+		 * @param num_threads Number of threads (0 for default, negative to use all available threads).
+		 */
+		void set_num_threads(int num_threads);
+
+		/**
 		 * Scale the image by a factor.
 		 * @param f Factor to scale by
 		 * @return True on success, false on failure.
@@ -171,6 +177,9 @@ class RasterImage {
 		 * @param max_value Maximum pixel value supported by the values argument. Assumes that any pixel values exceeding this value is remapped to the last value in the values argument.
 		 */
 		void remap_values(const unsigned char *values, unsigned char max_value);
+
+	protected:
+		int num_threads;	///< Number of threads to parallelize to.
 
 	private:
 		Magick::FilterTypes resampling_filter;	///< Enum index of the resampling filter used.

--- a/vsm/include/version.hpp
+++ b/vsm/include/version.hpp
@@ -17,9 +17,10 @@
 #pragma once
 
 #define CM_CONVERTER_NAME_STR		"cm-vsm"
-#define CM_CONVERTER_VERSION_STR	"0.1.20"
+#define CM_CONVERTER_VERSION_STR	"0.1.21"
 
 // Changelog
+//  0.1.21  Speed optimizations.
 //  0.1.20  CLI argument to disable PNG output.
 //  0.1.19  Fix semi-transparent cloud class for Segments.AI labels.
 //  0.1.18  Separate NO_DATA, SATURATED_OR_DEFECTIVE and UNCLASSIFIED from SCL classification scheme.

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -70,7 +70,7 @@ const unsigned char ESA_S2_Image_Operator::fmsc_scl_value_map[4] = {
 
 ESA_S2_Image::ESA_S2_Image():
 	tile_size(512), scl_value_map(nullptr), max_scl_value(12), f_downscale(1), f_overlap(0.0f),
-	store_png(false), read_tiled(false) {
+	store_png(false), read_tiled(false), num_threads(0) {
 }
 ESA_S2_Image::~ESA_S2_Image() {}
 
@@ -112,6 +112,10 @@ void ESA_S2_Image::set_png_output(bool enabled) {
 
 void ESA_S2_Image::set_tiled_input(bool enabled) {
 	read_tiled = enabled;
+}
+
+void ESA_S2_Image::set_num_threads(int num_threads) {
+	this->num_threads = num_threads;
 }
 
 std::string ESA_S2_Image::get_product_name_from_path(const std::filesystem::path &path) {
@@ -333,6 +337,7 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 	float tile_size_div = (tile_size - tile_size * f_overlap) / div_f;
 
 	img_src.set_deflate_level(deflate_factor);
+	img_src.set_num_threads(num_threads);
 
 	// Propagate overlap factor for NetCDF metadata.
 	img_src.f_overlap = f_overlap;
@@ -440,6 +445,7 @@ bool ESA_S2_Image::splitTIF(const std::filesystem::path &path_in, const std::fil
 	float tile_size_div = (tile_size - tile_size * f_overlap) / div_f;
 
 	img_src.set_deflate_level(deflate_factor);
+	img_src.set_num_threads(num_threads);
 
 	// Propagate overlap factor for NetCDF metadata.
 	img_src.f_overlap = f_overlap;
@@ -554,6 +560,7 @@ bool ESA_S2_Image::splitPNG(const std::filesystem::path &path_in, const std::fil
 	img_src.f_overlap = f_overlap;
 
 	img_src.set_deflate_level(deflate_factor);
+	img_src.set_num_threads(num_threads);
 
 	// Get image dimensions.
 	retval &= img_src.load_header(path_in);

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -333,7 +333,8 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 	img_src.product_name = get_product_name_from_path(path_in);
 
 	// Get image dimensions.
-	retval &= img_src.load_header(path_in);
+	// retval &= img_src.load_header(path_in);
+	retval &= img_src.load_whole(path_in);
 
 	int w = img_src.main_geometry.width();
 
@@ -368,7 +369,8 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 			sy1 += tile_size * f_overlap / div_f;
 
 			// Load the source image.
-			img_src.load_subset(path_in, sx0, sy0, sx1, sy1);
+			// img_src.load_subset(path_in, sx0, sy0, sx1, sy1);
+			img_src.subset_whole(sx0, sy0, sx1, sy1);
 
 			// Remap pixel values for SCL.
 			if (data_type == ESA_S2_Image_Operator::DT_SCL) {
@@ -397,8 +399,9 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 			ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
 
 			// Save PNG.
-			if (store_png)
+			if (store_png) {
 				img_src.save(ss_path_out_png.str());
+			}
 			// Add to NetCDF.
 			img_src.add_to_netcdf(ss_path_out_nc.str(), ESA_S2_Image_Operator::data_type_name[data_type]);
 

--- a/vsm/lib/raster/esa_s2.cpp
+++ b/vsm/lib/raster/esa_s2.cpp
@@ -68,7 +68,10 @@ const unsigned char ESA_S2_Image_Operator::fmsc_scl_value_map[4] = {
 	0   // 2 - 255                     -> NO_DATA
 };
 
-ESA_S2_Image::ESA_S2_Image(): tile_size(512), scl_value_map(nullptr), max_scl_value(12), f_downscale(1), f_overlap(0.0f), store_png(true) {}
+ESA_S2_Image::ESA_S2_Image():
+	tile_size(512), scl_value_map(nullptr), max_scl_value(12), f_downscale(1), f_overlap(0.0f),
+	store_png(false), read_tiled(false) {
+}
 ESA_S2_Image::~ESA_S2_Image() {}
 
 void ESA_S2_Image::set_tile_size(int tile_size) {
@@ -105,6 +108,10 @@ void ESA_S2_Image::set_resampling_method(const std::string &m) {
 
 void ESA_S2_Image::set_png_output(bool enabled) {
 	store_png = enabled;
+}
+
+void ESA_S2_Image::set_tiled_input(bool enabled) {
+	read_tiled = enabled;
 }
 
 std::string ESA_S2_Image::get_product_name_from_path(const std::filesystem::path &path) {
@@ -332,9 +339,11 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 	// Assign product name from the input path.
 	img_src.product_name = get_product_name_from_path(path_in);
 
-	// Get image dimensions.
-	// retval &= img_src.load_header(path_in);
-	retval &= img_src.load_whole(path_in);
+	// Either load the full image or load only the header.
+	if (read_tiled)
+		retval &= img_src.load_header(path_in);
+	else
+		retval &= img_src.load_whole(path_in);
 
 	int w = img_src.main_geometry.width();
 
@@ -368,9 +377,11 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 			sx1 += tile_size * f_overlap / div_f;
 			sy1 += tile_size * f_overlap / div_f;
 
-			// Load the source image.
-			// img_src.load_subset(path_in, sx0, sy0, sx1, sy1);
-			img_src.subset_whole(sx0, sy0, sx1, sy1);
+			// Subset the source image.
+			if (read_tiled)
+				img_src.load_subset(path_in, sx0, sy0, sx1, sy1);
+			else
+				img_src.subset_whole(sx0, sy0, sx1, sy1);
 
 			// Remap pixel values for SCL.
 			if (data_type == ESA_S2_Image_Operator::DT_SCL) {
@@ -395,18 +406,17 @@ bool ESA_S2_Image::splitJP2(const std::filesystem::path &path_in, const std::fil
 
 			std::filesystem::create_directories(ss_path_out.str());
 
-			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
-			ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
-
 			// Save PNG.
 			if (store_png) {
+				ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
 				img_src.save(ss_path_out_png.str());
 			}
 			// Add to NetCDF.
+			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
 			img_src.add_to_netcdf(ss_path_out_nc.str(), ESA_S2_Image_Operator::data_type_name[data_type]);
 
 			// Potential post-processing of the file.
-			if (!op(ss_path_out_png.str(), data_type))
+			if (!op(ss_path_out.str(), data_type))
 				return false;
 		}
 	}
@@ -507,17 +517,17 @@ bool ESA_S2_Image::splitTIF(const std::filesystem::path &path_in, const std::fil
 
 			std::filesystem::create_directories(ss_path_out.str());
 
-			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
-			ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
-
 			// Save PNG.
-			if (store_png)
+			if (store_png) {
+				ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
 				img_src.save(ss_path_out_png.str());
+			}
 			// Add to NetCDF.
+			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
 			img_src.add_to_netcdf(ss_path_out_nc.str(), ESA_S2_Image_Operator::data_type_name[data_type]);
 
 			// Potential post-processing of the file.
-			if (!op(ss_path_out_png.str(), data_type))
+			if (!op(ss_path_out.str(), data_type))
 				return false;
 		}
 	}
@@ -615,17 +625,18 @@ bool ESA_S2_Image::splitPNG(const std::filesystem::path &path_in, const std::fil
 
 			std::filesystem::create_directories(ss_path_out.str());
 
-			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
-			ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
 
 			// Save PNG.
-			if (store_png)
+			if (store_png) {
+				ss_path_out_png << ss_path_out.str() << path_in.stem().string() << "_" << "tile" << "_" << xi << "_" << yi << ".png";
 				img_src.save(ss_path_out_png.str());
+			}
 			// Add to NetCDF.
+			ss_path_out_nc << ss_path_out.str() << extract_index_date(path_in) << "_" << "tile" << "_" << xi << "_" << yi << ".nc";
 			img_src.add_to_netcdf(ss_path_out_nc.str(), ESA_S2_Image_Operator::data_type_name[data_type]);
 
 			// Potential post-processing of the file.
-			if (!op(ss_path_out_png.str(), data_type))
+			if (!op(ss_path_out.str(), data_type))
 				return false;
 		}
 	}

--- a/vsm/lib/raster/jp2_image.cpp
+++ b/vsm/lib/raster/jp2_image.cpp
@@ -78,8 +78,10 @@ bool JP2_Image::load_header(const std::filesystem::path &path) {
 			throw std::exception();
 		}
 
-		// Limit to a single thread (allows to parallelize over multiple JP2 files).
-		opj_codec_set_threads(l_codec, 1);
+		if (num_threads > 0)
+			opj_codec_set_threads(l_codec, num_threads);
+		else if (num_threads < 0)
+			opj_codec_set_threads(l_codec, opj_get_num_cpus());
 
 		// Read file header with image size, number of components, etc.
 		if (!opj_read_header(l_stream, l_codec, &l_image)) {
@@ -337,8 +339,10 @@ bool JP2_Image::load_whole(const std::filesystem::path &path) {
 			throw std::exception();
 		}
 
-		// Limit to a single thread (allows to parallelize over multiple JP2 files).
-		opj_codec_set_threads(l_codec, 1);
+		if (num_threads > 0)
+			opj_codec_set_threads(l_codec, num_threads);
+		else if (num_threads < 0)
+			opj_codec_set_threads(l_codec, opj_get_num_cpus());
 
 		// Read file header with image size, number of components, etc.
 		if (!opj_read_header(l_stream, l_codec, &l_image)) {
@@ -362,7 +366,7 @@ bool JP2_Image::load_whole(const std::filesystem::path &path) {
 		main_geometry.width(w);
 		main_geometry.height(h);
 
-		float r, g, b, f;
+		float f;
 		if (l_image->comps->prec <= 8) {
 			main_depth = 8;
 			f = 1 / 255.0f;
@@ -436,7 +440,6 @@ bool JP2_Image::load_whole(const std::filesystem::path &path) {
 
 bool JP2_Image::subset_whole(int da_x0, int da_y0, int da_x1, int da_y1) {
 	Magick::Geometry f_geom = whole_image->size();
-	unsigned long f_w = f_geom.width();
 	unsigned long w = da_x1 - da_x0;
 	unsigned long h = da_y1 - da_y0;
 	unsigned long w_clamped = w, h_clamped = h;

--- a/vsm/lib/raster/raster_image.cpp
+++ b/vsm/lib/raster/raster_image.cpp
@@ -353,8 +353,6 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 
 		// Store content.
 		if (c == 1) {
-			Magick::ColorGray col;
-
 			if (main_depth > 8) {
 				RasterBufferPan<float> dst_px(size);
 
@@ -362,8 +360,7 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
-						col = src_px[yw + x];
-						dst_px.v[fyw + x] = col.shade();
+						dst_px.v[fyw + x] = ((float) src_px[yw + x].green) / MaxRGB;
 					}
 				}
 				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v);
@@ -374,13 +371,11 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
-						col = src_px[yw + x];
-						dst_px.v[fyw + x] = (int) (col.shade() * 255);
+						dst_px.v[fyw + x] = (int) (src_px[yw + x].green * 255 / MaxRGB);
 					}
 				}
 				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v);
 			}
-
 
 		} else if (c == 3) {
 			RasterBufferRGB<unsigned char> dst_px(size);

--- a/vsm/lib/raster/raster_image.cpp
+++ b/vsm/lib/raster/raster_image.cpp
@@ -82,7 +82,10 @@ RasterBufferRGB<T>::~RasterBufferRGB() {
 	delete [] b;
 }
 
-RasterImage::RasterImage(): subset(nullptr), main_depth(0), main_num_components(0), f_overlap(0.0f), deflate_level(9), scaling_factor(1.0f) {
+RasterImage::RasterImage():
+	subset(nullptr), main_depth(0), main_num_components(0), f_overlap(0.0f), num_threads(0),
+	deflate_level(9), scaling_factor(1.0f)
+{
 	set_resampling_filter("");
 }
 RasterImage::~RasterImage() {
@@ -113,6 +116,10 @@ Magick::FilterTypes RasterImage::set_resampling_filter(const std::string &filter
 		resampling_filter_name = "undefined";
 	}
 	return resampling_filter;
+}
+
+void RasterImage::set_num_threads(int num_threads) {
+	this->num_threads = num_threads;
 }
 
 void RasterImage::clear() {
@@ -348,7 +355,6 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 		int nd = sizeof(dimids) / sizeof(dimids[0]);
 
 		Magick::PixelPacket *src_px = subset->getPixels(0, 0, w, h);
-		float src_val;
 		unsigned int yw, fyw;
 
 		// Store content.

--- a/vsm/lib/raster/raster_image.cpp
+++ b/vsm/lib/raster/raster_image.cpp
@@ -353,6 +353,8 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 
 		// Store content.
 		if (c == 1) {
+			Magick::ColorGray col;
+
 			if (main_depth > 8) {
 				RasterBufferPan<float> dst_px(size);
 
@@ -360,8 +362,8 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
-						src_val = Magick::ColorGray(src_px[yw + x]).shade();
-						dst_px.v[fyw + x] = src_val;
+						col = src_px[yw + x];
+						dst_px.v[fyw + x] = col.shade();
 					}
 				}
 				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v);
@@ -372,8 +374,8 @@ bool RasterImage::add_to_netcdf(const std::filesystem::path &path, const std::st
 					yw = y * w;
 					fyw = (h - 1 - y) * w;
 					for (unsigned int x=0; x<w; x++) {
-						src_val = Magick::ColorGray(src_px[yw + x]).shade();
-						dst_px.v[fyw + x] = (int) (src_val * 255);
+						col = src_px[yw + x];
+						dst_px.v[fyw + x] = (int) (col.shade() * 255);
 					}
 				}
 				add_layer_to_netcdf(ncid, path, name_in_netcdf, w, h, dimids, nd, (const void *) dst_px.v);

--- a/vsm/vsm/main.cpp
+++ b/vsm/vsm/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 
 	if (argc < 2) {
 		std::cerr << "Usage: " << CM_CONVERTER_NAME_STR
-			<< " [-d S2_PATH] [-D CVAT_PATH] [-r CVAT_XML -n NETCDF] [-b BANDS] [-R SUPERVISELY_DIR -t TILENAME -n NETCDF] [-A CVAT_SAI_PATH] [-S TILESIZE [-s SHRINK]] [-f DEFLATE_LEVEL] [-m RESAMPLING_METHOD] [-o OVERLAP] [--png] [--tiled]" << std::endl
+			<< " [-d S2_PATH] [-D CVAT_PATH] [-r CVAT_XML -n NETCDF] [-b BANDS] [-R SUPERVISELY_DIR -t TILENAME -n NETCDF] [-A CVAT_SAI_PATH] [-S TILESIZE [-s SHRINK]] [-f DEFLATE_LEVEL] [-m RESAMPLING_METHOD] [-o OVERLAP] [--png] [--tiled] [-j JOBS]" << std::endl
 			<< "\twhere S2_PATH points to the .SAFE directory of an ESA S2 L2A or L1C product." << std::endl
 			<< "\tCVAT_PATH points to the .CVAT directory (pre-processed ESA S2 product)." << std::endl
 			<< "\tCVAT_XML points to a CVAT annotations.xml file." << std::endl
@@ -75,7 +75,8 @@ int main(int argc, char* argv[]) {
 			<< "\tSHRINK is the factor by which to downscale from the 10 x 10 m^2 S2 bands (default: -1 (original size))." << std::endl
 			<< "\tDEFLATE_LEVEL is the compression factor for NETCDF (between 0 and 9, where 9 is the highest level of compression)." << std::endl
 			<< "\tRESAMPLING_METHOD defines a preferred way for resampling (point, box, cubic or sinc)." << std::endl
-			<< "\tOVERLAP Overlap between sub-tiles (between 0 and 0.5)." << std::endl;
+			<< "\tOVERLAP Overlap between sub-tiles (between 0 and 0.5)." << std::endl
+			<< "\tJOBS Number of threads to parallelize to (0 for default, negative to use all available threads)." << std::endl;
 		return 1;
 	}
 
@@ -90,6 +91,7 @@ int main(int argc, char* argv[]) {
 	float overlap = 0.0f;
 	bool output_png = false;
 	bool tiled_input = false;
+	int num_jobs = 0;
 	for (int i=0; i<argc; i++) {
 		if (!strncmp(argv[i], "-d", 2))
 			arg_path_s2_dir.assign(argv[i + 1]);
@@ -121,6 +123,8 @@ int main(int argc, char* argv[]) {
 			output_png = true;
 		else if (!strncmp(argv[i], "--tiled", 7))
 			tiled_input = true;
+		else if (!strncmp(argv[i], "-j", 2))
+			num_jobs = std::atoi(argv[i + 1]);
 	}
 
 	if (arg_path_s2_dir.length() > 0) {
@@ -151,6 +155,7 @@ int main(int argc, char* argv[]) {
 		img.set_resampling_method(arg_resampling_method);
 		img.set_png_output(output_png);
 		img.set_tiled_input(tiled_input);
+		img.set_num_threads(num_jobs);
 
 		img.process(path_dir_in, path_dir_out, img_op, bands);
 	} else if (arg_path_cvat_dir.length() > 0) {


### PR DESCRIPTION
A few speed optimizations:
* By default, the whole JP2 file is decoded at once (use `--tiled` to override).
* Number of threads for JP2 decoding can be supplied as a command-line argument (`-j JOBS`).
* By default, PNGs are not stored (use `--png` to override).
* Less class constructors, destructors in pixel-loops.