### PR TITLE
Standard gcc, g++ for ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,8 @@ jobs:
     # Install system dependencies
     - name: Installing system dependencies
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt update
-        sudo apt-get install -y gcc-9 g++-9 python3-pip libopenjp2-7-dev libgdal-dev gdal-bin libexpat1-dev libgraphicsmagick++1-dev libnetcdf-dev libcppunit-dev doxygen
+        sudo apt-get install -y gcc g++ python3-pip libopenjp2-7-dev libgdal-dev gdal-bin libexpat1-dev libgraphicsmagick++1-dev libnetcdf-dev libcppunit-dev doxygen
         pip3 install cget
 
     # Install dependencies with cget
@@ -42,7 +41,7 @@ jobs:
     - name: Running CMake
       run: |
         cd vsm/build
-        cmake -DCMAKE_CXX_COMPILER=g++-9 ..
+        cmake ..
 
     # Build
     - name: Building


### PR DESCRIPTION
Skip PPA add for latest toolchain and drop the specific dependence on g++-9.